### PR TITLE
Update Dockerfile to Trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Version 0.1
 
-FROM ubuntu:quantal
+FROM ubuntu:trusty
 MAINTAINER Jannis Leidel "jannis@leidel.info"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Ubuntu has deprecated the archives for quantal, causing this to now fail for new builds without a modification to the `sources.list` configuration file. Further more, this plugin works just fine with Trusty. So let's just use that :)
